### PR TITLE
Simplify R spec management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,6 @@ all:
 install:
 	mkdir -p $(DESTDIR)$(PREFIX)/lib/rpm/fileattrs
 	$(INSTALL) -m0644 R.attr $(DESTDIR)$(PREFIX)/lib/rpm/fileattrs
+	mkdir -p $(DESTDIR)$(PREFIX)/lib/rpm/macros.d
+	$(INSTALL) -m0644 macros.R-extra $(DESTDIR)$(PREFIX)/lib/rpm/macros.d
 	$(INSTALL) -m0755 R-deps.R $(DESTDIR)$(PREFIX)/lib/rpm/

--- a/R-deps.R
+++ b/R-deps.R
@@ -85,8 +85,7 @@ generate_package_deps <- function(path, types) {
   pkgpath <- dirname(path)  # Drop DESCRIPTION; point to package path instead.
   desc <- packageDescription(basename(pkgpath), lib.loc = dirname(pkgpath))
   if (all(types == "Provides")) {
-    cat("R(", desc$Package, ") = ", normalize_version(desc$Version), "\n",
-	sep = "")
+    cat("R(", desc$Package, ") = ", normalize_version(desc$Version), "\n", sep = "")
   } else {
     deps <- lapply(types, function(t) parse_deps(desc[[t]]))
     deps <- do.call(rbind, deps)

--- a/R.attr
+++ b/R.attr
@@ -1,5 +1,3 @@
 %__R_provides	%{_rpmconfigdir}/R-deps.R Provides
 %__R_requires	%{_rpmconfigdir}/R-deps.R Depends Imports
-%__R_suggests	%{_rpmconfigdir}/R-deps.R Suggests
-%__R_enhances	%{_rpmconfigdir}/R-deps.R Enhances
 %__R_path	^(%{_datadir}|%{_libdir})/R/library/[^/]+/DESCRIPTION$

--- a/macros.R-extra
+++ b/macros.R-extra
@@ -1,0 +1,207 @@
+# Macros to replace overly complicated references to CRAN URLs and source files.
+# %cran_source -
+#   Expands to the CRAN URL for a package
+#   Accepts zero to three arguments:
+#   1:  The CRAN version, defaulting to %version.
+#   2:  The CRAN project name, defaulting to %packname if it is defined.
+#       If not, R- will be stripped from %name and %packname defined to that.
+#   3:  The file extension, defaulting to %__r_default_extension (tar.gz).
+#   Requires %__cran_package_url_template and %__r_default_extension to be defined.
+#   %__cran_package_url_template will undergo substitution (case-sensitive):
+#   *  "PACKNAME" will be replaced with the above CRAN project name.
+#   *  "PACKVERSION" will be replaced with the above CRAN version.
+#   *  "EXTENSION" will be replaced with the above extension.
+#
+# %cran_url -
+#   Expands to the CRAN URL for a package
+#   Accepts zero or one arguments:
+#   1:  The CRAN project name, defaulting to %packname if it is defined.
+#       If not, R- will be stripped from %name and %packname defined to that.
+#   Requires %__cran_project_url_template to be defined.
+#   %__cran_project_url_template will undergo substitution (case-sensitive):
+#   *  "PACKNAME" will be replaced with the above CRAN project name.
+
+%__cran_project_url_template https://cran.r-project.org/package=PACKNAME
+%__cran_package_url_template %{__cran_project_url_template}&version=PACKVERSION#/PACKNAME_PACKVERSION.EXTENSION
+
+%__bioc_project_url_base     https://bioconductor.org/packages/release/bioc
+%__bioc_project_url_template %{__bioc_project_url_base}/html/PACKNAME.html
+%__bioc_package_url_template %{__bioc_project_url_base}/src/contrib/PACKNAME_PACKVERSION.EXTENSION
+
+%__r_default_extension tar.gz
+
+%__r_packname %{lua:
+    -- try %packname, then %name with 'R-' stripped
+    local src = rpm.expand('%packname')
+\
+    if src == '%packname' then
+        src = string.gsub(rpm.expand('%name'), "^R%-", "")
+    end
+\
+    print(src)
+}
+
+%cran_source() %{lua:
+    local ver = rpm.expand('%1')
+    local src = rpm.expand('%2')
+    local ext = rpm.expand('%3')
+    local url = rpm.expand('%__cran_package_url_template')
+\
+    -- If no first argument, use %version
+    if ver == '%1' then
+        ver = rpm.expand('%version')
+    end
+\
+    -- If no second argument, use %__r_packname
+    if src == '%2' then
+        src = rpm.expand('%__r_packname')
+    end
+\
+    -- If no third argument, use the preset default extension
+    if ext == '%3' then
+        ext = rpm.expand('%__r_default_extension')
+    end
+\
+    -- Now substitute in all the values
+    url = string.gsub(url, "PACKNAME", src)
+    url = string.gsub(url, "PACKVERSION", ver)
+    url = string.gsub(url, "EXTENSION", ext)
+\
+    print(url)
+}
+
+%bioc_source() %{lua:
+    local ver = rpm.expand('%1')
+    local src = rpm.expand('%2')
+    local ext = rpm.expand('%3')
+    local url = rpm.expand('%__bioc_package_url_template')
+\
+    -- If no first argument, use %version
+    if ver == '%1' then
+        ver = rpm.expand('%version')
+    end
+\
+    -- If no second argument, use %__r_packname
+    if src == '%2' then
+        src = rpm.expand('%__r_packname')
+    end
+\
+    -- If no third argument, use the preset default extension
+    if ext == '%3' then
+        ext = rpm.expand('%__r_default_extension')
+    end
+\
+    -- Now substitute in all the values
+    url = string.gsub(url, "PACKNAME", src)
+    url = string.gsub(url, "PACKVERSION", ver)
+    url = string.gsub(url, "EXTENSION", ext)
+\
+    print(url)
+}
+
+%cran_url() %{lua:
+    local src = rpm.expand('%1')
+    local url = rpm.expand('%__cran_project_url_template')
+\
+    -- If no first argument, try %__r_packname
+    if src == '%1' then
+        src = rpm.expand('%__r_packname')
+    end
+\
+    -- Substitute in the package name
+    url = string.gsub(url, "PACKNAME", src)
+\
+    print(url)
+}
+
+%bioc_url() %{lua:
+    local src = rpm.expand('%1')
+    local url = rpm.expand('%__bioc_project_url_template')
+\
+    -- If no first argument, try %__r_packname
+    if src == '%1' then
+        src = rpm.expand('%__r_packname')
+    end
+\
+    -- Substitute in the package name
+    url = string.gsub(url, "PACKNAME", src)
+\
+    print(url)
+}
+
+# The basic sections
+
+%r_prep %{lua:\
+    local packname = rpm.expand('%__r_packname')
+    local autosetup = rpm.expand("%{autosetup -c -n " .. packname .. "}")
+\
+    print(autosetup .. "\\\n")
+}
+
+%r_install %{lua:\
+    local rlibdir = rpm.expand('%rlibdir')
+    local bindir = rpm.expand('%_bindir')
+    local packname = rpm.expand('%__r_packname')
+    local buildroot = rpm.expand('%buildroot')
+\
+    -- A function to simplify conditionally adding to the file list
+    local function add_file(file, type)
+        if (file ~= nil) then
+            print("[[ -e " .. buildroot .. rlibdir .. "/" .. packname .. "/" .. file .. " ]] && ")
+        end
+        print("echo '")
+        if (type ~= nil) then
+            print("%" .. type .. " ")
+        end
+        print(rlibdir .. "/" .. packname)
+        if (file ~= nil) then
+            print("/" .. file)
+        end
+        print("' >> " .. packname .. ".files\\\n")
+    end
+\
+    print("mkdir -p " .. buildroot .. rlibdir .. "\\\n")
+    print(bindir .. "/R CMD INSTALL -l " .. buildroot .. rlibdir .. " " .. packname .. "\\\n")
+    print("test -d " .. packname .. "/src && (cd " .. packname .. "/src; rm -f *.o *.so)\\\n")
+    print("rm -f " .. buildroot .. rlibdir .. "/R.css\\\n")
+\
+    -- R packages have a somewhat regularlized file structure
+    -- This could be pushed out to a shell script and called like %find_lang is
+    -- called.  But for now we'll just inline the code.
+    -- print("\\\n# Generate a default file list\\\n")
+    -- add_file(nil, "dir")
+    -- add_file("html/", "doc")
+    -- add_file("libs", "dir")
+    -- add_file("libs/" .. packname .. ".so")
+    -- add_file("DESCRIPTION")
+    -- add_file("COPYING", "license")
+    -- add_file("LICENSE", "license")
+    -- add_file("NEWS", "doc")
+    -- add_file("INDEX")
+    -- add_file("NAMESPACE")
+    -- add_file("Meta/")
+    -- add_file("R/")
+    -- add_file("help/")
+\
+    -- print("ls -lR " .. buildroot .. "\\\n")
+}
+
+%r_check %{lua:\
+    local bindir = rpm.expand('%_bindir')
+    local packname = rpm.expand('%__r_packname')
+\
+    print("export LANG=C.UTF-8\\\n")
+    print("export _R_CHECK_FORCE_SUGGESTS_=0\\\n")
+    print(bindir .. "/R CMD check " .. packname .. " --ignore-vignettes\\\n")
+}
+
+%r_noarch_package %{lua:\
+    rpm.define("rlibdir  %{_datadir}/R/library")
+    print("BuildArch: noarch\\\n")
+    print("BuildRequires: R-devel tex(latex)\\\n")
+}
+
+%r_archful_package %{lua:\
+    rpm.define("rlibdir  %{_libdir}/R/library")
+    print("BuildRequires: R-devel tex(latex)\\\n")
+}


### PR DESCRIPTION
This is a work in progress. After the latest painful mass rebuild of R packages, we need to rethink how we package them, especially everything related to Suggests. My idea is to include **only hard dependencies** + the package that is being used for the testing framework (typically, testthat or tinytest), then ignore vignettes in the check section. This should always work per CRAN policy. If a package fails due to a missing dependency in the examples or tests, this is a bug and should be patched and reported upstream for fixing. cc'ing @spotrh @jasontibbitts

So this PR does two things:

- Disables automatic Suggests and Enhances, leaving only hard dependencies. This would simplify R packaging **a lot**, and also mass rebuilds, because we wouldn't need any bootstrapping (well, only for testthat dependencies).
- Builds on top of the inital work by @jasontibbitts and adds a macro file to simplify spec management.

For instance, with this proposal, the package units would be packaged as follows:

```
Name:           R-units
Version:        0.8.0
Release:        1%{?dist}
Summary:        Some summary

License:        GPLv2
URL:            %cran_url
Source0:        %cran_source 0.8-0

%r_archful_package

BuildRequires:  R-Rcpp-devel >= 0.12.10
# Testing framework
BuildRequires:  R-testthat >= 3.0.0

%description
Some descrition

%prep
%r_prep

%build

%install
%r_install

%check
%r_check

%files
...
```

Comments:

- I added %bioc_url and %bioc_source too.
- The %r_check macro automatically includes `--ignore-vignettes`.
- Note that I didn't include the proposal for automatic file generation. This could be problematic. Maybe we could add a macro to generate the files that are always present, and then the packager can add more on top of that.

Let's discuss this. The idea would be merge this and then rewrite the packaging guidelines for R packages to follow this style. 