### PR TITLE
Fix broken %__R_name on EPEL 10

### DIFF
--- a/macros.R-srpm
+++ b/macros.R-srpm
@@ -20,7 +20,7 @@
     local result = string.gsub(s, p, r)
     print(result)
 }
-%r_gsub() %{?gsub:%gsub %{**}}%{?!gsub:%_r_internal_gsub %{**}}
+%r_gsub() %{?gsub:%gsub %1 %2 %{quote:%3}}%{?!gsub:%_r_internal_gsub %{**}}
 
 # %name with "R-" stripped
 %__R_name %r_gsub %{name} ^R[-] %{quote:}


### PR DESCRIPTION
On EPEL 9 and Fedora it works as expected:

$ rpm -D "name R-abc" -E "%__R_name"
abc

But on EPEL 10 it fails:

$ rpm -D "name R-abc" -E "%__R_name"
error: lua script failed: [string "gsub"]:1: bad argument #3 to 'gsub' (string/function/table expected, got no value)

This leads to build failures like:

Start: build phase for R-littler-0.3.21-4.el10_3.src.rpm Start: build setup for R-littler-0.3.21-4.el10_3.src.rpm error: lua script failed: [string "gsub"]:1: bad argument #3 to 'gsub' (string/function/table expected, got no value)
  6<              (%gsub)
  5<            (%gsub)
  4<          (%r_gsub)
  3<        (%__R_name)
error: lua script failed: [string "__R_urls"]:4: error expanding macro
  2<      (%lua)
  1<    (%__R_urls)
  0<  (%cran_url)
URL:

Requoting the 3rd argument to gsub in the definition of r_gsub solves the issue,