### PR TITLE
Run tests on EPEL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           dnf config-manager --set-enabled crb
           dnf install -y epel-release
-          dnf install -y epel-rpm-macros make R-core
+          dnf install -y epel-rpm-macros diff make R-core
 
       - name: Run tests
         run: make test ${{ matrix.args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           dnf config-manager --set-enabled crb
           dnf install -y epel-release
-          dnf install -y epel-rpm-macros diff make R-core
+          dnf install -y epel-rpm-macros diffutils make R-core
 
       - name: Run tests
         run: make test ${{ matrix.args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - master
 
 jobs:
-  test:
+  rawhide:
     if: ${{ !contains(github.event.head_commit.message, '[ci skip]') }}
     runs-on: ubuntu-latest
     container:
@@ -24,3 +24,45 @@ jobs:
 
       - name: Run tests
         run: make test
+
+  epel9:
+    if: ${{ !contains(github.event.head_commit.message, '[ci skip]') }}
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/centos/centos:stream9
+      options: --privileged --cap-add=SYS_ADMIN
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          dnf install -y epel-release
+          dnf config-manager --set-enabled crb
+          dnf install -y epel-rpm-macros
+          dnf install -y make R-core
+
+      - name: Run tests
+        run: make test OFFLINE=1
+
+  epel10:
+    if: ${{ !contains(github.event.head_commit.message, '[ci skip]') }}
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/centos/centos:stream10
+      options: --privileged --cap-add=SYS_ADMIN
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          dnf install -y epel-release
+          dnf config-manager --set-enabled crb
+          dnf install -y epel-rpm-macros
+	  dnf install -y make R-core
+
+      - name: Run tests
+        run: make test OFFLINE=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,61 +8,36 @@ on:
       - master
 
 jobs:
-  rawhide:
+  test:
     if: ${{ !contains(github.event.head_commit.message, '[ci skip]') }}
     runs-on: ubuntu-latest
+    name: ${{ matrix.image }}:${{ matrix.tag }}
     container:
-      image: registry.fedoraproject.org/fedora:rawhide
+      image: ${{ matrix.repo }}/${{ matrix.image }}:${{ matrix.tag }}
       options: --privileged --cap-add=SYS_ADMIN
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - {image: 'fedora', tag: 'rawhide',  repo: 'registry.fedoraproject.org'}
+        - {image: 'centos', tag: 'stream9',  repo: 'quay.io/centos', args: 'OFFLINE=1' }
+        - {image: 'centos', tag: 'stream10', repo: 'quay.io/centos', args: 'OFFLINE=1' }
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install dependencies
+      - name: Install dependencies (Fedora)
+        if: ${{ matrix.image == 'fedora' }}
         run: dnf install -y make R-core spectool mock
 
-      - name: Run tests
-        run: make test
-
-  epel9:
-    if: ${{ !contains(github.event.head_commit.message, '[ci skip]') }}
-    runs-on: ubuntu-latest
-    container:
-      image: quay.io/centos/centos:stream9
-      options: --privileged --cap-add=SYS_ADMIN
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install dependencies
+      - name: Install dependencies (CentOS)
+        if: ${{ matrix.image == 'centos' }}
         run: |
-          dnf install -y epel-release
           dnf config-manager --set-enabled crb
-          dnf install -y epel-rpm-macros
-          dnf install -y make R-core
+          dnf install -y epel-release
+          dnf install -y epel-rpm-macros make R-core
 
       - name: Run tests
-        run: make test OFFLINE=1
-
-  epel10:
-    if: ${{ !contains(github.event.head_commit.message, '[ci skip]') }}
-    runs-on: ubuntu-latest
-    container:
-      image: quay.io/centos/centos:stream10
-      options: --privileged --cap-add=SYS_ADMIN
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: |
-          dnf install -y epel-release
-          dnf config-manager --set-enabled crb
-          dnf install -y epel-rpm-macros
-	  dnf install -y make R-core
-
-      - name: Run tests
-        run: make test OFFLINE=1
+        run: make test ${{ matrix.args }}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -19,7 +19,7 @@ for file in test-*.sh; do
         continue
     fi
     set -e
-    diff --color -u $file.out $file.out.new
+    diff --color --ignore-blank-lines -u $file.out $file.out.new
     echo "done"
     rm $file.out.new
 done


### PR DESCRIPTION
I would like to suggest to run the CI tests on EPEL 9 and 10 as well in order to detect glitches due to the older rpm versions there.

I am not an expert in writing .yml files, so this is a bit of cut-and-paste inspired by other projects. If you find something in the proposed change that is incorrect, unnecessary or not to your liking, please feel free to do whatever corrections or changes you find would improve it.